### PR TITLE
feat(deploy): add pull request previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,14 +3,23 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 env:
-  STAGE: prod
+  STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || (github.ref == 'refs/heads/main' && 'prod' || github.ref_name) }}
 jobs:
   deploy:
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Bun
@@ -25,3 +34,38 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          PULL_REQUEST: ${{ github.event.number }}
+          BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install
+      - name: Safety Check
+        run: |-
+          if [ "${{ env.STAGE }}" = "prod" ]; then
+            echo "ERROR: Cannot destroy prod environment in cleanup job"
+            exit 1
+          fi
+      - name: Destroy Preview Environment
+        run: bun run destroy -- -- --yes --stage ${{ env.STAGE }}
+        env:
+          ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
+          ALCHEMY_STATE_TOKEN: ${{ secrets.ALCHEMY_STATE_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          PULL_REQUEST: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -1,10 +1,16 @@
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
+import * as GitHub from "alchemy/GitHub";
+import * as Output from "alchemy/Output";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 export default Alchemy.Stack(
   "mackie-underdown-wiki",
-  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  {
+    providers: Layer.mergeAll(Cloudflare.providers(), GitHub.providers()),
+    state: Cloudflare.state(),
+  },
   Effect.gen(function* () {
     const stage = yield* Alchemy.Stage;
     const website = yield* Cloudflare.Website.StaticSite("website", {
@@ -12,11 +18,36 @@ export default Alchemy.Stack(
       command: "bun run build",
       outdir: "dist",
       dev: { command: "bun run astro dev" },
-      routes: [{ pattern: "mackie.underdown.wiki/*" }],
+      routes: stage === "prod" ? [{ pattern: "mackie.underdown.wiki/*" }] : undefined,
       assets: {
         htmlHandling: "drop-trailing-slash",
       },
     });
+
+    if (stage.startsWith("pr-") && process.env.PULL_REQUEST) {
+      const pullRequest = Number(process.env.PULL_REQUEST);
+      const buildSha = process.env.BUILD_SHA;
+
+      yield* GitHub.Comment("preview-comment", {
+        owner: "macklinu",
+        repository: "site",
+        issueNumber: pullRequest,
+        body: Output.interpolate`
+          ## Preview Deployed
+
+          **Website:** ${website.url}
+
+          Built from commit ${
+            buildSha
+              ? `[\`${buildSha.slice(0, 7)}\`](https://github.com/macklinu/site/commit/${buildSha})`
+              : "unknown"
+          }.
+
+          ---
+          <sub>This comment updates automatically with each push.</sub>
+        `,
+      });
+    }
 
     return { url: website.url };
   }),

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "turbo run dev",
     "build": "turbo run build",
     "deploy": "turbo run deploy",
+    "destroy": "turbo run destroy",
     "lint": "oxlint --disable-nested-config",
     "format": "oxfmt --disable-nested-config",
     "format:check": "oxfmt --check --disable-nested-config ."

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,23 @@
         "CLOUDFLARE_EMAIL",
         "CLOUDFLARE_API_TOKEN",
         "ALCHEMY_STATE_TOKEN",
-        "ALCHEMY_PASSWORD"
+        "ALCHEMY_PASSWORD",
+        "PULL_REQUEST",
+        "BUILD_SHA",
+        "GITHUB_TOKEN"
+      ]
+    },
+    "destroy": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "cache": false,
+      "passThroughEnv": [
+        "CLOUDFLARE_ACCOUNT_ID",
+        "CLOUDFLARE_EMAIL",
+        "CLOUDFLARE_API_TOKEN",
+        "ALCHEMY_STATE_TOKEN",
+        "ALCHEMY_PASSWORD",
+        "PULL_REQUEST",
+        "GITHUB_TOKEN"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- deploy a Cloudflare Workers preview for each internal pull request and post its URL as a managed PR comment
- keep the production route bound only to the `prod` stage
- destroy preview stages on PR close and pass deployment metadata through Turbo

## Verification
- `bun run format:check`
- `actionlint .github/workflows/deploy.yml`
- `bun run build`
- `bun apps/web/alchemy.run.ts`
- `PULL_REQUEST=258 GITHUB_TOKEN=placeholder bun run destroy -- -- --help`

Closes FFC-258.